### PR TITLE
Add additional parameter to support user assigned identity

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This Terraform module creates an [Azure API Management](https://docs.microsoft.c
 ## Version compatibility
 
 | Module version | Terraform version | AzureRM version |
-|----------------|-------------------| --------------- |
+| -------------- | ----------------- | --------------- |
 | >= 4.x.x       | 0.13.x            | >= 2.0          |
 | >= 3.x.x       | 0.12.x            | >= 2.0          |
 | >= 2.x.x       | 0.12.x            | < 2.0           |
@@ -78,68 +78,75 @@ module "apim" {
 }
 ```
 
+## Providers
+
+| Name    | Version |
+| ------- | ------- |
+| azurerm | ~> 2.0  |
+
 ## Inputs
 
-| Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
-| additional\_location | List of the name of the Azure Region in which the API Management Service should be expanded to. | `list(map(string))` | `[]` | no |
-| certificate\_configuration | List of certificate configurations | `list(map(string))` | `[]` | no |
-| client\_name | Client name/account used in naming | `string` | n/a | yes |
-| create\_management\_rule | Whether to create the NSG rule for the management port of the APIM. If true, nsg\_name variable must be set | `bool` | `false` | no |
-| create\_product\_group\_and\_relationships | Create local APIM groups with name identical to products and create a relationship between groups and products | `bool` | `false` | no |
-| custom\_name | Custom API Management name, generated if not set | `string` | `""` | no |
-| developer\_portal\_hostname\_configuration | Developer portal hostname configurations | `list(map(string))` | `[]` | no |
-| diag\_settings\_name | Custom name for the diagnostic settings of Application Gateway. | `string` | `""` | no |
-| enable\_http2 | Should HTTP/2 be supported by the API Management Service? | `bool` | `false` | no |
-| enable\_sign\_in | Should anonymous users be redirected to the sign in page? | `bool` | `false` | no |
-| enable\_sign\_up | Can users sign up on the development portal? | `bool` | `false` | no |
-| environment | Project environment | `string` | n/a | yes |
-| extra\_tags | Extra tags to add | `map(string)` | `{}` | no |
-| identity\_type | Type of Managed Service Identity that should be configured on this API Management Service | `string` | `"SystemAssigned"` | no |
-| location | Azure location for Eventhub. | `string` | n/a | yes |
-| location\_short | Short string for Azure location. | `string` | n/a | yes |
-| log\_categories | List of log categories to send | `list(string)` | `null` | no |
-| log\_destination\_type | Log sent to Log Analytics can be sent to 'Dedicated' log tables or the legacy 'AzureDiagnostics' | `string` | `"Dedicated"` | no |
-| logs\_destinations\_ids | List of destination resources IDs for logs diagnostic destination. Can be Storage Account, Log Analytics Workspace and Event Hub. No more than one of each can be set. | `list(string)` | `[]` | no |
-| logs\_storage\_retention | Retention in days for logs on Storage Account | `number` | `30` | no |
-| management\_hostname\_configuration | List of management hostname configurations | `list(map(string))` | `[]` | no |
-| management\_nsg\_rule\_priority | Priority of the NSG rule created for the management port of the APIM | `number` | `101` | no |
-| metric\_categories | List of metric categories to send | `list(string)` | `null` | no |
-| name\_prefix | Optional prefix for Network Security Group name | `string` | `""` | no |
-| named\_values | Map containing the name of the named values as key and value as values | `list(map(string))` | `[]` | no |
-| notification\_sender\_email | Email address from which the notification will be sent | `string` | `null` | no |
-| nsg\_name | NSG name of the subnet hosting the APIM to add the rule to allow management if the APIM is private | `string` | `null` | no |
-| nsg\_rg\_name | Name of the RG hosting the NSG if it's different from the one hosting the APIM | `string` | `null` | no |
-| policy\_configuration | Map of policy configuration | `map(string)` | `{}` | no |
-| portal\_hostname\_configuration | Legacy portal hostname configurations | `list(map(string))` | `[]` | no |
-| products | List of products to create | `list(string)` | `[]` | no |
-| proxy\_hostname\_configuration | List of proxy hostname configurations | `list(map(string))` | `[]` | no |
-| publisher\_email | The email of publisher/company. | `string` | n/a | yes |
-| publisher\_name | The name of publisher/company. | `string` | n/a | yes |
-| resource\_group\_name | Name of the resource group | `string` | n/a | yes |
-| scm\_hostname\_configuration | List of scm hostname configurations | `list(map(string))` | `[]` | no |
-| security\_configuration | Map of security configuration | `map(string)` | `{}` | no |
-| sku\_name | String consisting of two parts separated by an underscore. The fist part is the name, valid values include: Developer, Basic, Standard and Premium. The second part is the capacity | `string` | `"Basic_1"` | no |
-| stack | Project stack name | `string` | n/a | yes |
-| terms\_of\_service\_configuration | Map of terms of service configuration | `list(map(string))` | `[]` | no |
-| virtual\_network\_configuration | The id(s) of the subnet(s) that will be used for the API Management. Required when virtual\_network\_type is External or Internal | `list(string)` | `[]` | no |
-| virtual\_network\_type | The type of virtual network you want to use, valid values include: None, External, Internal. | `string` | `null` | no |
+| Name                                       | Description                                                                                                                                                                         | Type                | Default            | Required |
+| ------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------- | ------------------ | :------: |
+| additional\_location                       | List of the name of the Azure Region in which the API Management Service should be expanded to.                                                                                     | `list(map(string))` | `[]`               |    no    |
+| certificate\_configuration                 | List of certificate configurations                                                                                                                                                  | `list(map(string))` | `[]`               |    no    |
+| client\_name                               | Client name/account used in naming                                                                                                                                                  | `string`            | n/a                |   yes    |
+| create\_management\_rule                   | Whether to create the NSG rule for the management port of the APIM. If true, nsg\_name variable must be set                                                                         | `bool`              | `false`            |    no    |
+| create\_product\_group\_and\_relationships | Create local APIM groups with name identical to products and create a relationship between groups and products                                                                      | `bool`              | `false`            |    no    |
+| custom\_name                               | Custom API Management name, generated if not set                                                                                                                                    | `string`            | `""`               |    no    |
+| developer\_portal\_hostname\_configuration | Developer portal hostname configurations                                                                                                                                            | `list(map(string))` | `[]`               |    no    |
+| diag\_settings\_name                       | Custom name for the diagnostic settings of Application Gateway.                                                                                                                     | `string`            | `""`               |    no    |
+| enable\_http2                              | Should HTTP/2 be supported by the API Management Service?                                                                                                                           | `bool`              | `false`            |    no    |
+| enable\_sign\_in                           | Should anonymous users be redirected to the sign in page?                                                                                                                           | `bool`              | `false`            |    no    |
+| enable\_sign\_up                           | Can users sign up on the development portal?                                                                                                                                        | `bool`              | `false`            |    no    |
+| environment                                | Project environment                                                                                                                                                                 | `string`            | n/a                |   yes    |
+| extra\_tags                                | Extra tags to add                                                                                                                                                                   | `map(string)`       | `{}`               |    no    |
+| identity\_ids                              | A list of IDs for User Assigned Managed Identity resources to be assigned. This is required when type is set to UserAssigned or SystemAssigned, UserAssigned.                       | `list(string)`      | `[]`               |    no    |
+| identity\_type                             | Type of Managed Service Identity that should be configured on this API Management Service                                                                                           | `string`            | `"SystemAssigned"` |    no    |
+| location                                   | Azure location for Eventhub.                                                                                                                                                        | `string`            | n/a                |   yes    |
+| location\_short                            | Short string for Azure location.                                                                                                                                                    | `string`            | n/a                |   yes    |
+| log\_categories                            | List of log categories to send                                                                                                                                                      | `list(string)`      | `null`             |    no    |
+| log\_destination\_type                     | Log sent to Log Analytics can be sent to 'Dedicated' log tables or the legacy 'AzureDiagnostics'                                                                                    | `string`            | `"Dedicated"`      |    no    |
+| logs\_destinations\_ids                    | List of destination resources IDs for logs diagnostic destination. Can be Storage Account, Log Analytics Workspace and Event Hub. No more than one of each can be set.              | `list(string)`      | `[]`               |    no    |
+| logs\_storage\_retention                   | Retention in days for logs on Storage Account                                                                                                                                       | `number`            | `30`               |    no    |
+| management\_hostname\_configuration        | List of management hostname configurations                                                                                                                                          | `list(map(string))` | `[]`               |    no    |
+| management\_nsg\_rule\_priority            | Priority of the NSG rule created for the management port of the APIM                                                                                                                | `number`            | `101`              |    no    |
+| metric\_categories                         | List of metric categories to send                                                                                                                                                   | `list(string)`      | `null`             |    no    |
+| name\_prefix                               | Optional prefix for Network Security Group name                                                                                                                                     | `string`            | `""`               |    no    |
+| named\_values                              | Map containing the name of the named values as key and value as values                                                                                                              | `list(map(string))` | `[]`               |    no    |
+| notification\_sender\_email                | Email address from which the notification will be sent                                                                                                                              | `string`            | `null`             |    no    |
+| nsg\_name                                  | NSG name of the subnet hosting the APIM to add the rule to allow management if the APIM is private                                                                                  | `string`            | `null`             |    no    |
+| nsg\_rg\_name                              | Name of the RG hosting the NSG if it's different from the one hosting the APIM                                                                                                      | `string`            | `null`             |    no    |
+| policy\_configuration                      | Map of policy configuration                                                                                                                                                         | `map(string)`       | `{}`               |    no    |
+| portal\_hostname\_configuration            | Legacy portal hostname configurations                                                                                                                                               | `list(map(string))` | `[]`               |    no    |
+| products                                   | List of products to create                                                                                                                                                          | `list(string)`      | `[]`               |    no    |
+| proxy\_hostname\_configuration             | List of proxy hostname configurations                                                                                                                                               | `list(map(string))` | `[]`               |    no    |
+| publisher\_email                           | The email of publisher/company.                                                                                                                                                     | `string`            | n/a                |   yes    |
+| publisher\_name                            | The name of publisher/company.                                                                                                                                                      | `string`            | n/a                |   yes    |
+| resource\_group\_name                      | Name of the resource group                                                                                                                                                          | `string`            | n/a                |   yes    |
+| scm\_hostname\_configuration               | List of scm hostname configurations                                                                                                                                                 | `list(map(string))` | `[]`               |    no    |
+| security\_configuration                    | Map of security configuration                                                                                                                                                       | `map(string)`       | `{}`               |    no    |
+| sku\_name                                  | String consisting of two parts separated by an underscore. The fist part is the name, valid values include: Developer, Basic, Standard and Premium. The second part is the capacity | `string`            | `"Basic_1"`        |    no    |
+| stack                                      | Project stack name                                                                                                                                                                  | `string`            | n/a                |   yes    |
+| terms\_of\_service\_configuration          | Map of terms of service configuration                                                                                                                                               | `list(map(string))` | `[]`               |    no    |
+| virtual\_network\_configuration            | The id(s) of the subnet(s) that will be used for the API Management. Required when virtual\_network\_type is External or Internal                                                   | `list(string)`      | `[]`               |    no    |
+| virtual\_network\_type                     | The type of virtual network you want to use, valid values include: None, External, Internal.                                                                                        | `string`            | `null`             |    no    |
 
 ## Outputs
 
-| Name | Description |
-|------|-------------|
-| api\_management\_additional\_location | Map listing gateway\_regional\_url and public\_ip\_addresses associated |
-| api\_management\_gateway\_regional\_url | The Region URL for the Gateway of the API Management Service |
-| api\_management\_gateway\_url | The URL of the Gateway for the API Management Service |
-| api\_management\_id | The ID of the API Management Service |
-| api\_management\_identity | The identity of the API Management |
-| api\_management\_management\_api\_url | The URL for the Management API associated with this API Management service |
-| api\_management\_name | The name of the API Management Service |
-| api\_management\_portal\_url | The URL for the Publisher Portal associated with this API Management service |
-| api\_management\_private\_ip\_addresses | The Private IP addresses of the API Management Service |
-| api\_management\_public\_ip\_addresses | The Public IP addresses of the API Management Service |
-| api\_management\_scm\_url | The URL for the SCM Endpoint associated with this API Management service |
+| Name                                    | Description                                                                  |
+| --------------------------------------- | ---------------------------------------------------------------------------- |
+| api\_management\_additional\_location   | Map listing gateway\_regional\_url and public\_ip\_addresses associated      |
+| api\_management\_gateway\_regional\_url | The Region URL for the Gateway of the API Management Service                 |
+| api\_management\_gateway\_url           | The URL of the Gateway for the API Management Service                        |
+| api\_management\_id                     | The ID of the API Management Service                                         |
+| api\_management\_identity               | The identity of the API Management                                           |
+| api\_management\_management\_api\_url   | The URL for the Management API associated with this API Management service   |
+| api\_management\_name                   | The name of the API Management Service                                       |
+| api\_management\_portal\_url            | The URL for the Publisher Portal associated with this API Management service |
+| api\_management\_private\_ip\_addresses | The Private IP addresses of the API Management Service                       |
+| api\_management\_public\_ip\_addresses  | The Public IP addresses of the API Management Service                        |
+| api\_management\_scm\_url               | The URL for the SCM Endpoint associated with this API Management service     |
 
 ## Related documentation
 

--- a/r-api-management.tf
+++ b/r-api-management.tf
@@ -30,7 +30,8 @@ resource "azurerm_api_management" "apim" {
   }
 
   identity {
-    type = var.identity_type
+    type         = var.identity_type
+    identity_ids = var.identity_ids
   }
 
   dynamic "hostname_configuration" {

--- a/r-api-management.tf
+++ b/r-api-management.tf
@@ -31,7 +31,7 @@ resource "azurerm_api_management" "apim" {
 
   identity {
     type         = var.identity_type
-    identity_ids = var.identity_ids
+    identity_ids = replace(var.identity_type, "UserAssigned", "") == var.identity_type ? null : var.identity_ids
   }
 
   dynamic "hostname_configuration" {
@@ -41,6 +41,7 @@ resource "azurerm_api_management" "apim" {
       var.developer_portal_hostname_configuration,
       var.proxy_hostname_configuration,
     )) == 0 ? [] : ["fake"]
+
     content {
       dynamic "management" {
         for_each = var.management_hostname_configuration
@@ -52,6 +53,7 @@ resource "azurerm_api_management" "apim" {
           negotiate_client_certificate = lookup(management.value, "negotiate_client_certificate", false)
         }
       }
+
       dynamic "portal" {
         for_each = var.portal_hostname_configuration
         content {
@@ -62,6 +64,7 @@ resource "azurerm_api_management" "apim" {
           negotiate_client_certificate = lookup(portal.value, "negotiate_client_certificate", false)
         }
       }
+
       dynamic "developer_portal" {
         for_each = var.developer_portal_hostname_configuration
         content {
@@ -72,6 +75,7 @@ resource "azurerm_api_management" "apim" {
           negotiate_client_certificate = lookup(developer_portal.value, "negotiate_client_certificate", false)
         }
       }
+
       dynamic "proxy" {
         for_each = var.proxy_hostname_configuration
         content {
@@ -83,6 +87,7 @@ resource "azurerm_api_management" "apim" {
           negotiate_client_certificate = lookup(proxy.value, "negotiate_client_certificate", false)
         }
       }
+
       dynamic "scm" {
         for_each = var.scm_hostname_configuration
         content {

--- a/variables.tf
+++ b/variables.tf
@@ -191,6 +191,12 @@ variable "identity_type" {
   default     = "SystemAssigned"
 }
 
+variable "identity_ids" {
+  description = "A list of IDs for User Assigned Managed Identity resources to be assigned. This is required when type is set to UserAssigned or SystemAssigned, UserAssigned."
+  type        = list(string)
+  default     = []
+}
+
 variable "named_values" {
   description = "Map containing the name of the named values as key and value as values"
   type        = list(map(string))


### PR DESCRIPTION
User assigned identity is easy to use and can be created before APIM which solves some ordering issues, this PR adds a parameter to accept a list of identity_ids